### PR TITLE
added DataFrames.jl to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 Missings
+DataFrames


### PR DESCRIPTION
When installing uCSV on a fresh install of Julia, I noticed that it gave an error as I did not have DataFrames.jl installed. I thought maybe this should be added to REQUIRE so it is resolved automatically on install.

Thanks for the work on this, uCSV is really helpful to me!